### PR TITLE
bug fix for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CLANG_FLAGS -O3 -mavx2 -mavx -mfma -ffast-math CACHE STRING "Clang compilati
 
 set(CMAKE_CXX_STANDARD 11)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 add_subdirectory(src)
 add_subdirectory(tools)


### PR DESCRIPTION
Append local cmake modules to CMAKE_MODULE_PATH instead of overwriting
it. This is necessary in order to find FindTBB.cmake provided by the
anydsl runtime.