### PR TITLE
Include cstdint so uint32_t and similar types can be found.

### DIFF
--- a/tools/common/load_bvh.h
+++ b/tools/common/load_bvh.h
@@ -31,7 +31,7 @@ inline bool locate_block(std::istream& is, BvhType type) {
         is.seekg(offset, std::istream::cur);
 
         is.read((char*)&offset, sizeof(uint64_t));
-        if (is.gcount() != sizeof(std::uint64_t)) return false;
+        if (is.gcount() != sizeof(uint64_t)) return false;
         is.read((char*)&block_type, sizeof(uint32_t));
         if (is.gcount() != sizeof(uint32_t)) return false;
 

--- a/tools/fbuf2png/fbuf2png.cpp
+++ b/tools/fbuf2png/fbuf2png.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <png.h>
 #include <cstring>
+#include <cstdint>
 
 static void write_to_stream(png_structp png_ptr, png_bytep data, png_size_t length) {
     png_voidp a = png_get_io_ptr(png_ptr);


### PR DESCRIPTION
Development related fixes. Not sure why, but this is necessary for me to still be able  to compile rodent.